### PR TITLE
Create ExecutionInput via builder

### DIFF
--- a/src/main/kotlin/ktor/graphql/RequestHandler.kt
+++ b/src/main/kotlin/ktor/graphql/RequestHandler.kt
@@ -134,7 +134,7 @@ internal class RequestHandler(
                 .operationName(request.operationName)
                 .context(config.context)
                 .root(config.rootValue)
-                .variables(request.variables)
+                .variables(request.variables ?: emptyMap())
                 .build()
 
         return GraphQL

--- a/src/main/kotlin/ktor/graphql/RequestHandler.kt
+++ b/src/main/kotlin/ktor/graphql/RequestHandler.kt
@@ -129,12 +129,13 @@ internal class RequestHandler(
 
     private fun performRequest(): ExecutionResult {
 
-        val executionInput = ExecutionInput(
-                request.query,
-                request.operationName,
-                config.context,
-                config.rootValue,
-                request.variables)
+        val executionInput = ExecutionInput.newExecutionInput()
+                .query(request.query)
+                .operationName(request.operationName)
+                .context(config.context)
+                .root(config.rootValue)
+                .variables(request.variables)
+                .build()
 
         return GraphQL
                 .newGraphQL(schema)


### PR DESCRIPTION
I'm experimenting with GraphQL via Ktor 1.2.3 and Kotlin 1.3.41 using version 0.2.4 of this library. I'm generating schemas using `com.expedia:graphql-kotlin:0.6.1` which depends upon `com.graphql-java:graphql-java:13.0`.

When running this library's code against GraphQL Java version 13.0, an exception is thrown for any query run:
```
500 Internal Server Error: POST - /graphql
java.lang.AbstractMethodError: Method ktor/graphql/HttpGraphQLError.getErrorType()Lgraphql/ErrorClassification; is abstract
	at ktor.graphql.HttpGraphQLError.getErrorType(HttpGraphQLError.kt)
	at graphql.GraphqlErrorHelper.toSpecification(GraphqlErrorHelper.java:29)
	at graphql.GraphQLError.toSpecification(GraphQLError.java:59)
	at ktor.graphql.FormatResultKt.formatResult(formatResult.kt:25)
	at ktor.graphql.RequestHandler.sendResponse(RequestHandler.kt:114)
	at ktor.graphql.RequestHandler.doRequest(RequestHandler.kt:48)
	at ktor.graphql.RouteKt$graphQL$graphQLRoute$1.invokeSuspend(route.kt:19)
	at ktor.graphql.RouteKt$graphQL$graphQLRoute$1.invoke(route.kt)
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(PipelineContext.kt:268)
...
```

I found that GraphQL Java's `ExecutionInput#transform` method is called during it's internal request handling logic and, in version 13.0, this [triggers a failed assertion](https://github.com/graphql-java/graphql-java/blob/v13.0/src/main/java/graphql/ExecutionInput.java#L232) since the [Ktor Graphql provided `ExecutionInput`'s](https://github.com/excitement-engineer/ktor-graphql/blob/v0.2.4/src/main/kotlin/ktor/graphql/RequestHandler.kt#L132) `CacheControl` instance is null.

The null `CacheControl` check was introduced in version 13.0 in graphql-java/graphql-java#1493. Per the [GraphQL Java tests](https://github.com/graphql-java/graphql-java/blob/v13.0/src/test/groovy/graphql/ExecutionInputTest.groovy#L62), the tested approach for creating an `ExecutionInput` is via its builder.

This patch changes `ExecutionInput` creation to use the builder, which should be compatible with GraphQL Java version 9.0 as used by this library as well as 13.0. The version 13.0 builder provides a default `CacheControl` instance, thus avoiding the assertion failure.