### PR TITLE
Simplify error handling for invalid syntax

### DIFF
--- a/src/test/kotlin/ktor/graphql/ErrorHandlingTest.kt
+++ b/src/test/kotlin/ktor/graphql/ErrorHandlingTest.kt
@@ -144,8 +144,8 @@ object ErrorHandlingTest : Spek({
                     {
                         "errors": [
                             {
-                                "message": "Invalid Syntax",
-                                "locations": [{ "line": 1, "column": 0 }]
+                                "message": "Invalid Syntax : offending token 'synxtaxerror' at line 1 column 1",
+                                "locations": [{ "line": 1, "column": 1 }]
                             }
                         ]
                     }


### PR DESCRIPTION
Per #7, simplify the conversion of `InvalidSyntaxException` to `InvalidSyntaxError`. This creates a dependency on an `@Internal` graphql-java API, however.