### PR TITLE
Add support for headers with parameters

### DIFF
--- a/src/test/kotlin/ktor/graphql/PostTest.kt
+++ b/src/test/kotlin/ktor/graphql/PostTest.kt
@@ -286,4 +286,32 @@ object PostTest : Spek({
         )
     }
 
+    describe("supports application/json POST with content-subtypes") {
+        val query = """
+            query helloWho(${"$"}who: String) {
+                test(who: ${"$"}who)
+            }
+        """
+
+        val variables = mapOf(
+                "who" to "Dolly"
+        )
+
+        testResponse(
+                call = postRequest {
+                    setJsonBody(
+                            "query" to query,
+                            "variables" to variables
+                    )
+                    addHeader(HttpHeaders.ContentType, "application/json; charset=UTF-8")
+                },
+                json = """
+                {
+                    "data": {
+                        "test":"Hello Dolly"
+                    }
+                }
+                """
+        )
+    }
 })


### PR DESCRIPTION
The ApolloClient for Android automatically adds header parameters to the request

```Content-Type: application/json; charset=UTF-8```

This will cause `parseBody` function to miscategorize the request as a GraphQL request. This is because it compares `application/json` against `application/json; charset=UTF-8` which fails.

This approach allows us to ignore the header parameters and focus directly on the content sub type.