### PR TITLE
Fix encoding issue, default to UTF-8

### DIFF
--- a/src/main/kotlin/ktor/graphql/parseRequest/parseBody.kt
+++ b/src/main/kotlin/ktor/graphql/parseRequest/parseBody.kt
@@ -17,7 +17,7 @@ internal fun parseBody(body: String, contentType: ContentType): GraphQLRequest {
         return GraphQLRequest()
     }
 
-    return when(contentType) {
+    return when(contentType.withoutParameters()) {
         graphQLContentType -> requestGraphQL(body)
         ContentType.Application.Json -> requestJson(body)
         else -> GraphQLRequest()

--- a/src/main/kotlin/ktor/graphql/parseRequest/parseRequest.kt
+++ b/src/main/kotlin/ktor/graphql/parseRequest/parseRequest.kt
@@ -2,11 +2,13 @@ package ktor.graphql.parseRequest
 
 import ktor.graphql.GraphQLRequest
 import io.ktor.application.ApplicationCall
-import io.ktor.http.HttpStatusCode
-import io.ktor.request.contentType
-import io.ktor.request.receiveText
+import io.ktor.http.*
+import io.ktor.request.*
+import io.ktor.utils.io.charsets.*
 import ktor.graphql.HttpException
 import ktor.graphql.HttpGraphQLError
+import ktor.graphql.parseRequest.parseQueryString
+import kotlin.text.Charsets
 
 /**
  * See https://graphql.org/learn/serving-over-http/
@@ -25,7 +27,7 @@ internal suspend fun parseGraphQLRequest(call: ApplicationCall): GraphQLRequest 
 
 private suspend fun parseRequest(call: ApplicationCall): GraphQLRequest {
 
-    val body = call.receiveText()
+    val body = call.receiveTextWithCorrectEncoding()
     val contentType = call.request.contentType()
     val bodyRequest = parseBody(body, contentType)
 
@@ -41,3 +43,18 @@ private suspend fun parseRequest(call: ApplicationCall): GraphQLRequest {
 }
 
 
+/**
+ * Receive the request as String.
+ * If there is no Content-Type in the HTTP header specified use ISO_8859_1 as default charset, see https://www.w3.org/International/articles/http-charset/index#charset.
+ * But use UTF-8 as default charset for application/json, see https://tools.ietf.org/html/rfc4627#section-3
+ */
+private suspend fun ApplicationCall.receiveTextWithCorrectEncoding(): String {
+    fun ContentType.defaultCharset(): Charset = when (this) {
+        ContentType.Application.Json -> Charsets.UTF_8
+        else -> Charsets.ISO_8859_1
+    }
+
+    val contentType = request.contentType()
+    val suitableCharset = contentType.charset() ?: contentType.defaultCharset()
+    return receiveStream().bufferedReader(charset = suitableCharset).readText()
+}

--- a/src/test/kotlin/ktor/graphql/PostTest.kt
+++ b/src/test/kotlin/ktor/graphql/PostTest.kt
@@ -255,31 +255,51 @@ object PostTest : Spek({
         )
     }
 
-    describe("supports POST raw text query with GET variable values") {
-
-        val query = """
+    val whoQuery = """
             query helloWho(${"$"}who: String){
                 test(who: ${"$"}who)
             }
         """.trimIndent()
+
+    describe("supports POST raw text query with GET variable values") {
 
         testResponse(
                 call = postRequest {
                     uri = urlString(
                             "variables" to """
                                 {
-                                    "who": "Dolly"
+                                    "who": "test OLÀ ПРИВЕТ"
                                 }
                             """,
                             "operationName" to "helloWho"
                     )
-                    setBody(query)
+                    setBody(whoQuery)
                     addHeader(HttpHeaders.ContentType, "application/graphql")
                 },
                 json = """
                 {
                     "data": {
-                        "test":"Hello Dolly"
+                        "test":"Hello test OLÀ ПРИВЕТ"
+                    }
+                }
+                """
+        )
+    }
+
+    describe("it uses the right encoding") {
+        testResponse(
+                call = postJSONRequest {
+                    setJsonBody("query" to whoQuery,
+                            "variables" to mapOf(
+                                    "who" to "OLÀ ПРИВЕТ"
+                            ),
+                            "operationName" to "helloWho"
+                    )
+                },
+                json = """
+                {
+                    "data": {
+                        "test":"Hello OLÀ ПРИВЕТ"
                     }
                 }
                 """

--- a/src/test/kotlin/ktor/graphql/PostTest.kt
+++ b/src/test/kotlin/ktor/graphql/PostTest.kt
@@ -306,4 +306,26 @@ object PostTest : Spek({
         )
     }
 
+    describe("it allows for setting the encoding by the client") {
+        testResponse(
+                call = postRequest {
+                    addHeader(HttpHeaders.ContentType, "application/json; charset=${Charsets.ISO_8859_1}")
+                    setJsonBody("query" to whoQuery,
+                            "variables" to mapOf(
+                                    "who" to "OLÀ ПРИВЕТ"
+                            ),
+                            "operationName" to "helloWho"
+                    )
+                },
+                // The response is to show that if we use another charset then it doesn't parse the passed characters
+                json = """
+                {
+                    "data": {
+                        "test":"Hello OLÃ ÐÐ ÐÐÐÐ¢"
+                    }
+                }
+                """
+        )
+    }
+
 })


### PR DESCRIPTION
ktor defaults to ISO-8859-1 instead of UTF-8 for the encoding. This may cause issues for certain characters in the body. To overcome this we set the default to UTF-8 unless specified otherwise.

Fixes #23, override #19, override #14